### PR TITLE
Upgrade py38-fail2ban py38-certbot to py39

### DIFF
--- a/nextcloud.json
+++ b/nextcloud.json
@@ -19,8 +19,8 @@
         "nginx",
         "mysql80-server",
         "redis",
-        "py38-fail2ban",
-        "py38-certbot"
+        "py39-fail2ban",
+        "py39-certbot"
     ],
     "packagesite": "http://pkg.FreeBSD.org/${ABI}/latest",
     "fingerprints": {


### PR DESCRIPTION
Fix according to https://www.truenas.com/community/threads/py38-fail2ban-py38-certbot-refusing-to-fetch-artifact-and-run-post_in.102216/post-704644